### PR TITLE
Remove source attribution from guitar processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Guitar data is submitted as JSON with nested structures:
 - `manufacturer`: Company information
 - `model`: Model specifications and production details
 - `individual_guitar`: Specific instrument with serial numbers and significance
-- `source_attribution`: Data source and reliability information
+
 
 See `sample_single.json` and `sample_batch.json` for examples.
 

--- a/README_guitar_processor.md
+++ b/README_guitar_processor.md
@@ -10,8 +10,7 @@ A complete submission requires these top-level properties:
 {
   "manufacturer": { ... },
   "model": { ... },
-  "individual_guitar": { ... },
-  "source_attribution": { ... }
+  "individual_guitar": { ... }
 }
 ```
 
@@ -197,20 +196,7 @@ A complete submission requires these top-level properties:
 - `reliability_score` (integer, 1-10): 1=least reliable, 10=most reliable
 - `notes` (string): Additional information about the source
 
-### Source Attribution Example
 
-```json
-{
-  "source_attribution": {
-    "source_name": "Fender 1954 Product Catalog",
-    "source_type": "manufacturer_catalog",
-    "url": "https://archive.org/fender-1954-catalog",
-    "publication_date": "1954-01-01",
-    "reliability_score": 10,
-    "notes": "Official manufacturer catalog, highest reliability"
-  }
-}
-```
 
 ## 5. Specifications Object
 
@@ -357,12 +343,6 @@ Here's a complete example showing all components together:
     "significance_notes": "One of the first 100 Stratocasters ever produced",
     "current_estimated_value": 50000.00,
     "condition_rating": "excellent"
-  },
-  "source_attribution": {
-    "source_name": "Fender 1954 Product Catalog",
-    "source_type": "manufacturer_catalog",
-    "reliability_score": 10,
-    "notes": "Official manufacturer catalog"
   }
 }
 ```
@@ -529,8 +509,7 @@ The CLI supports both single submissions and batch processing with arrays of sub
 {
   "manufacturer": { ... },
   "model": { ... },
-  "individual_guitar": { ... },
-  "source_attribution": { ... }
+  "individual_guitar": { ... }
 }
 ```
 
@@ -542,8 +521,7 @@ The CLI supports both single submissions and batch processing with arrays of sub
     "model": { ... }
   },
   {
-    "model": { ... },
-    "source_attribution": { ... }
+    "model": { ... }
   },
   {
     "manufacturer": { ... },

--- a/Requirements/next-steps-data-cycle.md
+++ b/Requirements/next-steps-data-cycle.md
@@ -49,7 +49,7 @@ These files are tracked in git and serve as the **official examples** for the pr
 #### **`example_guitar_models.json`** 
 - **Purpose**: Example structure for manufacturer and model data
 - **Content**: 3 manufacturers + 100+ models from Fender, Gibson, Epiphone
-- **Structure**: Array of objects with `manufacturer`, `model`, and `source_attribution` sections
+- **Structure**: Array of objects with `manufacturer` and `model` sections
 - **Status**: ✅ **Valid for processing** - contains complete, well-structured data
 
 #### **`example_guitar_with_images.json`**
@@ -61,7 +61,7 @@ These files are tracked in git and serve as the **official examples** for the pr
 #### **`slash_collection.json`**
 - **Purpose**: Real-world example of individual guitar data
 - **Content**: 30+ individual guitars from Slash's collection using fallback references
-- **Structure**: Array of objects with `individual_guitar` and `source_attribution`
+- **Structure**: Array of objects with `individual_guitar`
 - **Status**: ✅ **Valid for processing** - uses fallback manufacturer/model references
 
 ### **✅ 2. Non-Version-Controlled JSON Files (Additional Valid Examples)**

--- a/database/create.sql
+++ b/database/create.sql
@@ -34,6 +34,7 @@ CREATE TABLE manufacturers (
     website VARCHAR(255),
     status VARCHAR(20) DEFAULT 'active' CHECK (status IN ('active', 'defunct', 'acquired')),
     notes TEXT,
+    created_by VARCHAR(100),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
@@ -64,6 +65,7 @@ CREATE TABLE models (
     msrp_original DECIMAL(10,2),
     currency VARCHAR(3) DEFAULT 'USD',
     description TEXT,
+    created_by VARCHAR(100),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(manufacturer_id, name, year)
@@ -93,6 +95,7 @@ CREATE TABLE individual_guitars (
     condition_rating VARCHAR(20) CHECK (condition_rating IN ('mint', 'excellent', 'very_good', 'good', 'fair', 'poor', 'relic')),
     modifications TEXT,
     provenance_notes TEXT,
+    created_by VARCHAR(100),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     

--- a/example_guitar_models.json
+++ b/example_guitar_models.json
@@ -6,12 +6,6 @@
       "founded_year": 1946,
       "website": "https://www.fender.com",
       "status": "active"
-    },
-    "source_attribution": {
-      "source_name": "Fender Guitar Database Compilation",
-      "source_type": "website",
-      "url": "https://findmyguitar.com/fender",
-      "reliability_score": 9
     }
   },
   {
@@ -21,12 +15,6 @@
       "founded_year": 1902,
       "website": "https://www.gibson.com",
       "status": "active"
-    },
-    "source_attribution": {
-      "source_name": "Gibson Model Database",
-      "source_type": "manufacturer_catalog",
-      "url": "https://www.gibson.com",
-      "reliability_score": 10
     }
   },
   {
@@ -35,12 +23,6 @@
       "country": "USA",
       "founded_year": 1873,
       "status": "acquired"
-    },
-    "source_attribution": {
-      "source_name": "Epiphone Historical Database",
-      "source_type": "website",
-      "url": "https://www.epiphone.com",
-      "reliability_score": 9
     }
   },
   {

--- a/example_guitar_with_images.json
+++ b/example_guitar_with_images.json
@@ -47,10 +47,5 @@
         "caption": "Back view showing beautiful flame maple"
       }
     ]
-  },
-  "source_attribution": {
-    "source_name": "Guitar Registry Test",
-    "source_type": "manual_entry",
-    "reliability_score": 9
   }
 } 

--- a/guitar_processor_cli.py
+++ b/guitar_processor_cli.py
@@ -353,11 +353,6 @@ def create_sample_files():
             "significance_level": "historic",
             "significance_notes": "Famous 1959 Les Paul",
             "current_estimated_value": 500000.00
-        },
-        "source_attribution": {
-            "source_name": "Guitar Registry Test",
-            "source_type": "manual_entry",
-            "reliability_score": 9
         }
     }
     

--- a/slash_collection.json
+++ b/slash_collection.json
@@ -12,11 +12,6 @@
       "modifications": "Refinished from brighter cherry sunburst to duller finish. Has medium neck and three-piece top. Cigarette burn mark from dropping cigarette.",
       "provenance_notes": "Acquired by Slash in 1988 during Guns N' Roses tour. Called 'Jessica' by Slash.",
       "description": "Faded cherry sunburst Les Paul Standard with medium neck and three-piece top"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -29,11 +24,6 @@
       "current_estimated_value": 25000.0,
       "condition_rating": "excellent",
       "modifications": "Rosewood neck (custom specification instead of standard ebony)"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -46,11 +36,6 @@
       "current_estimated_value": 30000.0,
       "condition_rating": "excellent",
       "modifications": "Seymour Duncan pickups replacing mini humbuckers, modified neck profile"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -63,11 +48,6 @@
       "current_estimated_value": 15000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Based on guitar seen at Chicago NAMM show that looked like Slash's guitars. Slash no longer owns one."
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -81,11 +61,6 @@
       "condition_rating": "excellent",
       "modifications": "Snake inlay on neck, hand-carved and painted details",
       "provenance_notes": "Custom made for Snakepit, limited run production. Slash wishes he had more."
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -99,11 +74,6 @@
       "condition_rating": "excellent",
       "modifications": "Pickup covers were already removed when Slash acquired the guitar",
       "provenance_notes": "Purchased from Albert Molinaro before Use Your Illusion recording for $250,000"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -116,11 +86,6 @@
       "current_estimated_value": 280000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Purchased along with 1958 Korina Flying V"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -133,11 +98,6 @@
       "significance_notes": "Modern reissue of the famous 1958 Korina Flying V, part of Gibson's Murphy Lab aged series.",
       "current_estimated_value": 8000.0,
       "condition_rating": "excellent"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -150,11 +110,6 @@
       "significance_notes": "Modern reissue of the famous 1958 Korina Explorer, part of Gibson's Murphy Lab aged series.",
       "current_estimated_value": 8000.0,
       "condition_rating": "excellent"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -167,11 +122,6 @@
       "current_estimated_value": 12000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Christmas gift from Megan in 2021"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -185,11 +135,6 @@
       "current_estimated_value": 450000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Acquired to replace returned Joe Perry Les Paul"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -204,11 +149,6 @@
       "condition_rating": "good",
       "modifications": "Floyd Rose tremolo system, active electronics bypassed for passive use",
       "provenance_notes": "Purchased from acquaintance on the street in 1989 or 1990"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -221,11 +161,6 @@
       "current_estimated_value": 8000.0,
       "condition_rating": "excellent",
       "modifications": "Custom 10-string configuration"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -238,11 +173,6 @@
       "current_estimated_value": 5000.0,
       "condition_rating": "good",
       "provenance_notes": "Purchased from friend in 1989 or 1990 on Highland Boulevard"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -256,11 +186,6 @@
       "current_estimated_value": 8000.0,
       "condition_rating": "good",
       "provenance_notes": "Slash's first quality electric guitar"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -273,11 +198,6 @@
       "current_estimated_value": 8000.0,
       "condition_rating": "good",
       "provenance_notes": "Owned since before Guns N' Roses, one of three Travis Bean guitars"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -291,11 +211,6 @@
       "current_estimated_value": 8500.0,
       "condition_rating": "very_good",
       "provenance_notes": "Purchased from Norm's Rare Guitars"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -309,11 +224,6 @@
       "current_estimated_value": 15000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Recently acquired, same year and similar serial number to 'Jessica'"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -326,11 +236,6 @@
       "current_estimated_value": 12000.0,
       "condition_rating": "excellent",
       "modifications": "Custom Slash design: 6-string acoustic top, 6-string electric bottom"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -343,11 +248,6 @@
       "current_estimated_value": 12000.0,
       "condition_rating": "excellent",
       "modifications": "Custom Slash design: 6-string acoustic top, 6-string electric bottom"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -360,11 +260,6 @@
       "current_estimated_value": 12000.0,
       "condition_rating": "excellent",
       "modifications": "Custom Slash design: 12-string acoustic top, 6-string electric bottom"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -378,11 +273,6 @@
       "current_estimated_value": 50000.0,
       "condition_rating": "relic",
       "provenance_notes": "Acquired through manager Alan Niven. Slash never met luthier Kris Derrig who made it."
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -397,11 +287,6 @@
       "condition_rating": "excellent",
       "modifications": "Piezo pickup system removed",
       "provenance_notes": "First full production Slash signature line with Gibson"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -414,11 +299,6 @@
       "current_estimated_value": 15000.0,
       "condition_rating": "excellent",
       "modifications": "Brazilian rosewood neck (prototype specification)"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -432,11 +312,6 @@
       "current_estimated_value": 400000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Gibson made replicas of this guitar"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -450,11 +325,6 @@
       "current_estimated_value": 400000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Purchased from Albert Molinaro"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -467,11 +337,6 @@
       "current_estimated_value": 25000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Used for Living the Dream album recording"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -484,11 +349,6 @@
       "current_estimated_value": 30000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Purchased from Norm's Rare Guitars, seen on 'Guitar of the Day'"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -502,11 +362,6 @@
       "current_estimated_value": 450000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Primary studio recording guitar"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -520,11 +375,6 @@
       "current_estimated_value": 18000.0,
       "condition_rating": "very_good",
       "provenance_notes": "Purchased used"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -538,11 +388,6 @@
       "current_estimated_value": 12000.0,
       "condition_rating": "excellent",
       "provenance_notes": "Inspired by stolen 1957 Les Paul, named after the thief"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -555,11 +400,6 @@
       "current_estimated_value": 500.0,
       "condition_rating": "poor",
       "provenance_notes": "Found in uncle's closet, Slash's first guitar experience"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -573,11 +413,6 @@
       "condition_rating": "poor",
       "modifications": "Eventually destroyed by putting through wall",
       "provenance_notes": "Traded from Memphis Explorer copy, destroyed due to being unplayable"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -590,11 +425,6 @@
       "current_estimated_value": 200.0,
       "condition_rating": "fair",
       "provenance_notes": "Slash's first electric guitar, traded away due to uncomfortable shape"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   },
   {
@@ -608,11 +438,6 @@
       "condition_rating": "fair",
       "modifications": "Tailpiece held on with bolts",
       "provenance_notes": "Acquired from babysitting clients during teenage years"
-    },
-    "source_attribution": {
-      "source_name": "Gibson TV (The Collection: Slash)",
-      "source_type": "website",
-      "reliability_score": 8
     }
   }
 ]


### PR DESCRIPTION
Remove the unused and partially implemented source attribution system from the processor CLI and replace it with a simple `created_by` field for basic record tracking.

The source attribution system was identified as unnecessary from a business perspective and had an incomplete implementation (validating input but not creating records or linking them). This change simplifies the data processing logic and reduces complexity while still providing essential information about record creation.

---
Linear Issue: [REG-16](https://linear.app/dotsur/issue/REG-16/remove-source-attribution-system-from-processor-cli)

<a href="https://cursor.com/background-agent?bcId=bc-1101b4ed-1107-49e7-a8a7-f1abcb40806a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1101b4ed-1107-49e7-a8a7-f1abcb40806a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatically captures and stores “Created by” metadata on new manufacturers, models, and individual guitars.
* Refactor
  * Removed support for source attribution in submissions and processing.
* Documentation
  * Updated all docs and examples to remove source_attribution fields and sections.
  * Revised sample JSONs (single, batch, collections) to reflect the new schema.
* Chores
  * Database updated with an optional Created By column for relevant records.
  * CLI sample output adjusted to exclude source attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->